### PR TITLE
Change minus to dash in Inverse-chi-squared

### DIFF
--- a/Slides/BayesLearnL3.lyx
+++ b/Slides/BayesLearnL3.lyx
@@ -421,7 +421,7 @@ Posterior
 \begin_inset Formula 
 \begin{gather*}
 \theta|\sigma^{2},\mathbf{x}\sim N\left(\bar{x},\frac{\sigma^{2}}{n}\right)\\
-\sigma^{2}|\mathbf{x}\sim\mathrm{Inv}-\chi^{2}(n-1,s^{2}),
+\sigma^{2}|\mathbf{x}\sim\mathrm{Inv}\text{-}\chi^{2}(n-1,s^{2}),
 \end{gather*}
 
 \end_inset


### PR DESCRIPTION
Minus symbol is slightly misleading, because it can be interpreted as Inverse of minus Chi-squared distribution. Moreover, in the .tex version of the slides it looks like it was actually `\mathrm{Inv}\text{-}\chi^{2}` (line 349).