### PR TITLE
Change minus to dash in Inv-Chi^2

### DIFF
--- a/Labs/Lab1.lyx
+++ b/Labs/Lab1.lyx
@@ -356,7 +356,7 @@ for
 \end_inset
 
  is the 
-\begin_inset Formula $Inv-\chi^{2}(n,\tau^{2})$
+\begin_inset Formula $Inv\text{-}\chi^{2}(n,\tau^{2})$
 \end_inset
 
  distribution, where
@@ -385,7 +385,7 @@ Simulate
 \end_inset
 
 ) and compare with the theoretical 
-\begin_inset Formula $Inv-\chi^{2}(n,\tau^{2})$
+\begin_inset Formula $Inv\text{-}\chi^{2}(n,\tau^{2})$
 \end_inset
 
  posterior distribution.

--- a/Slides/BayesLearnL3.lyx
+++ b/Slides/BayesLearnL3.lyx
@@ -421,7 +421,7 @@ Posterior
 \begin_inset Formula 
 \begin{gather*}
 \theta|\sigma^{2},\mathbf{x}\sim N\left(\bar{x},\frac{\sigma^{2}}{n}\right)\\
-\sigma^{2}|\mathbf{x}\sim\mathrm{Inv}-\chi^{2}(n-1,s^{2}),
+\sigma^{2}|\mathbf{x}\sim\mathrm{Inv}\text{-}\chi^{2}(n-1,s^{2}),
 \end{gather*}
 
 \end_inset

--- a/Slides/BayesLearnL5.lyx
+++ b/Slides/BayesLearnL5.lyx
@@ -659,7 +659,7 @@ Joint prior for
 \begin_inset Formula 
 \begin{align*}
 \beta|\sigma^{2} & \sim N\left(\mu_{0},\sigma^{2}\Omega_{0}^{-1}\right)\\
-\sigma^{2} & \sim Inv-\chi^{2}\left(\nu_{0},\sigma_{0}^{2}\right)
+\sigma^{2} & \sim Inv\text{-}\chi^{2}\left(\nu_{0},\sigma_{0}^{2}\right)
 \end{align*}
 
 \end_inset
@@ -675,7 +675,7 @@ Posterior
 \begin_inset Formula 
 \begin{align*}
 \beta|\sigma^{2},\mathbf{y} & \sim N\left[\mu_{n},\sigma^{2}\Omega_{n}^{-1}\right]\\
-\sigma^{2}\vert\mathbf{y} & \sim Inv-\chi^{2}\left(\nu_{n},\sigma_{n}^{2}\right)
+\sigma^{2}\vert\mathbf{y} & \sim Inv\text{-}\chi^{2}\left(\nu_{n},\sigma_{n}^{2}\right)
 \end{align*}
 
 \end_inset
@@ -1233,7 +1233,7 @@ use a prior for
 
 \begin_layout Itemize
 One possibility: 
-\begin_inset Formula $\lambda\sim Inv-\chi^{2}(\eta_{0},\lambda_{0})$
+\begin_inset Formula $\lambda\sim Inv\text{-}\chi^{2}(\eta_{0},\lambda_{0})$
 \end_inset
 
 .
@@ -1262,8 +1262,8 @@ Hierarchical setup:
 \begin{align*}
 \mathbf{y}|\beta,\mathbf{X} & \sim N(\mathbf{X}\beta,\sigma^{2}I_{n})\\
 \beta|\sigma^{2},\lambda & \sim N\left(0,\sigma^{2}\lambda^{-1}I_{m}\right)\\
-\sigma^{2} & \sim Inv-\chi^{2}(\nu_{0},\sigma_{0}^{2})\\
-\lambda & \sim Inv-\chi^{2}(\eta_{0},\lambda_{0})
+\sigma^{2} & \sim Inv\text{-}\chi^{2}(\nu_{0},\sigma_{0}^{2})\\
+\lambda & \sim Inv\text{-}\chi^{2}(\eta_{0},\lambda_{0})
 \end{align*}
 
 \end_inset
@@ -1314,7 +1314,7 @@ The joint posterior of
 \begin_inset Formula 
 \begin{align*}
 \beta|\sigma^{2},\lambda,\mathbf{y} & \sim N\left(\mu_{n},\Omega_{n}^{-1}\right)\\
-\sigma^{2}|\lambda,\mathbf{y} & \sim Inv-\chi^{2}\left(\nu_{n},\sigma_{n}^{2}\right)\\
+\sigma^{2}|\lambda,\mathbf{y} & \sim Inv\text{-}\chi^{2}\left(\nu_{n},\sigma_{n}^{2}\right)\\
 p(\lambda|\mathbf{y}) & \propto\sqrt{\frac{\left|\Omega_{0}\right|}{\left|X'X+\Omega_{0}\right|}}\left(\frac{\nu_{n}\sigma_{n}^{2}}{2}\right)^{-\nu_{n}/2}\cdot p(\lambda)
 \end{align*}
 


### PR DESCRIPTION
Change `-` in `\mathrm{Inv}-\chi^{2}` and `Inv-\chi^{2}` to `\text{-}`. This might help understanding that this is inverse Chi-squared distribution rather than Inverse negative Chi-squared distribution (not sure if such thing even exists).

Unlike the previous pull request, this one changes `-` to `\text{-}` in all files.